### PR TITLE
Restore ES6 module syntax and package.json

### DIFF
--- a/GameEngine/Core/Tests/Entity.test.js
+++ b/GameEngine/Core/Tests/Entity.test.js
@@ -1,6 +1,6 @@
 // GameEngine/Core/Tests/Entity.test.js
-const Entity = require('../Entity');
-const Component = require('../Component'); // Assuming Component is needed if TestComponent extends it
+import Entity from '../Entity.js';
+import Component from '../Component.js';
 
 class TestComponent extends Component {
   constructor() {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dots",
+  "version": "0.1.0",
+  "description": "A sandbox for systems architects—watching simple rules evolve into complex behaviors",
+  "type": "module",
+  "scripts": {
+    "test": "node GameEngine/Core/Tests/Entity.test.js"
+  }
+}


### PR DESCRIPTION
- Fix Entity.test.js imports after revert to CommonJS syntax
- Recreate package.json with module type configuration
- Ensures tests run successfully with proper ES6 module resolution

🤖 Generated with [Claude Code](https://claude.ai/code)