### PR TITLE
Fix module export and entities iteration issues

### DIFF
--- a/GameEngine/Systems/RenderSystem.js
+++ b/GameEngine/Systems/RenderSystem.js
@@ -7,7 +7,7 @@ class RenderSystem {
         const context = this.worldView.getContext();
         this.worldView.clear();
 
-        for (const entity of world.entities) {
+        for (const entity of Object.values(world.entities)) {
             const appearance = entity.components.Appearance;
             const transform = entity.components.Transform;
 

--- a/GameEngine/UI/WorldView.js
+++ b/GameEngine/UI/WorldView.js
@@ -19,3 +19,5 @@ class WorldView {
         return this.canvas;
     }
 }
+
+export default WorldView;


### PR DESCRIPTION
- Add missing export default to WorldView.js
- Fix RenderSystem to iterate over Object.values(world.entities) instead of world.entities directly
- Resolves "doesn't provide an export named: 'default'" and "world.entities is not iterable" errors

🤖 Generated with [Claude Code](https://claude.ai/code)