### PR TITLE
Fix ES6 module syntax errors and add package.json

### DIFF
--- a/GameEngine/Core/Tests/Entity.test.js
+++ b/GameEngine/Core/Tests/Entity.test.js
@@ -1,6 +1,6 @@
 // GameEngine/Core/Tests/Entity.test.js
-const Entity = require('../Entity');
-const Component = require('../Component'); // Assuming Component is needed if TestComponent extends it
+import Entity from '../Entity.js';
+import Component from '../Component.js';
 
 class TestComponent extends Component {
   constructor() {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dots",
+  "version": "0.1.0",
+  "description": "A sandbox for systems architects—watching simple rules evolve into complex behaviors",
+  "type": "module",
+  "scripts": {
+    "test": "node GameEngine/Core/Tests/Entity.test.js"
+  }
+}


### PR DESCRIPTION
- Convert Entity.test.js from CommonJS to ES6 imports
- Add package.json with "type": "module" for proper ES6 module resolution
- Resolves "doesn't provide an export named: 'default'" import errors

🤖 Generated with [Claude Code](https://claude.ai/code)