### PR TITLE
feat: Initialize and render world boundary

### DIFF
--- a/GameEngine/Components/Transform.js
+++ b/GameEngine/Components/Transform.js
@@ -1,0 +1,10 @@
+import Component from '../Core/Component.js';
+
+class Transform extends Component {
+  constructor(x = 0, y = 0) {
+    super();
+    this.position = { x, y };
+  }
+}
+
+export default Transform;

--- a/GameEngine/Entities/BoundaryEntity.js
+++ b/GameEngine/Entities/BoundaryEntity.js
@@ -2,10 +2,16 @@ import Entity from '../Core/Entity.js';
 import RadiusComponent from '../Components/RadiusComponent.js';
 import ColliderComponent from '../Components/ColliderComponent.js';
 import GrowComponent from '../Components/GrowComponent.js';
+import Transform from '../Components/Transform.js';
+import Appearance from '../Components/Appearance.js';
 
 class BoundaryEntity extends Entity {
   constructor(initialRadius = 500, growthRate = 20, growthInterval = 1000) {
     super();
+
+    // Add Transform and Appearance components
+    this.addComponent(new Transform(0, 0));
+    this.addComponent(new Appearance({ shape: 'circle', color: '#CCCCCC' }));
 
     this.addComponent(new RadiusComponent(initialRadius));
     this.addComponent(new ColliderComponent());

--- a/GameEngine/Systems/RenderSystem.js
+++ b/GameEngine/Systems/RenderSystem.js
@@ -24,9 +24,17 @@ class RenderSystem {
                 context.fillStyle = color;
 
                 if (shape === 'circle') {
-                    const { radius } = appearance;
+                    let radiusToUse;
+                    if (entity.components.RadiusComponent) {
+                        radiusToUse = entity.components.RadiusComponent.radius;
+                    } else {
+                        radiusToUse = appearance.radius; // Fallback to Appearance component's radius
+                    }
+                    // Ensure radiusToUse has a sensible default if both are undefined, e.g., 10
+                    radiusToUse = radiusToUse || 10;
+
                     context.beginPath();
-                    context.arc(x, y, radius, 0, Math.PI * 2);
+                    context.arc(x, y, radiusToUse, 0, Math.PI * 2); // Use radiusToUse
                     context.fill();
                     context.closePath();
                 } else if (shape === 'rectangle') {


### PR DESCRIPTION
This commit introduces the following changes:

1.  Created `GameEngine/Components/Transform.js` to provide entities with a position in the world.
2.  Modified `GameEngine/Entities/BoundaryEntity.js`:
    *   Added `Transform` component, positioning it at (0,0).
    *   Added `Appearance` component with a circular shape and light gray color.
3.  Modified `GameEngine/Systems/RenderSystem.js`:
    *   Updated to prioritize `RadiusComponent.radius` for rendering circles if the entity possesses this component. Otherwise, it falls back to `Appearance.radius`.
    *   This allows the `BoundaryEntity`'s visual size to be directly driven by its `RadiusComponent`.
4.  Verified that the existing `GameEngine/Systems/GrowthSystem.js` will correctly update the `RadiusComponent` of the `BoundaryEntity`, leading to a visually growing boundary.

These changes ensure that at game initialization, a world boundary is created, centered, and rendered as a circle with an initial radius of 500. The boundary will also expand over time due to the `GrowComponent` and `GrowthSystem`.